### PR TITLE
Feature: Add Lenovo Legion Go 2 OLED

### DIFF
--- a/scripts/00-gamescope/displays/lenovo.legiongo2.oled.lua
+++ b/scripts/00-gamescope/displays/lenovo.legiongo2.oled.lua
@@ -1,0 +1,64 @@
+local legiongo2_oled_refresh_rates = {
+    30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
+    40, 41, 42, 43, 44, 45, 46, 47, 48, 49,
+    50, 51, 52, 53, 54, 55, 56, 57, 58, 59,
+    60, 61, 62, 63, 64, 65, 66, 67, 68, 69,
+    70, 71, 72, 73, 74, 75, 76, 77, 78, 79,
+    80, 81, 82, 83, 84, 85, 86, 87, 88, 89,
+    90, 91, 92, 93, 94, 95, 96, 97, 98, 99,
+    100, 101, 102, 103, 104, 105, 106, 107, 108, 109,
+    110, 111, 112, 113, 114, 115, 116, 117, 118, 119,
+    120, 121, 122, 123, 124, 125, 126, 127, 128, 129,
+    130, 131, 132, 133, 134, 135, 136, 137, 138, 139,
+    140, 141, 142, 143, 144
+}
+
+gamescope.config.known_displays.lenovo_legiongo2_oled = {
+    pretty_name = "Lenovo Legion Go 2 OLED",
+    hdr = {
+        supported = true,
+        force_enabled = false,
+        eotf = gamescope.eotf.pq,
+        max_content_light_level = 1100,
+        max_frame_average_luminance = 475,
+        min_content_light_level = 0
+    },
+    dynamic_refresh_rates = legiongo2_oled_refresh_rates,
+    dynamic_modegen = function(base_mode, refresh)
+        debug("Generating mode "..refresh.."Hz for Lenovo Legion Go 2 OLED")
+        local vfps = {
+            5072, 4868, 4676, 4496, 4327, 4167, 4016, 3873, 3738, 3610,
+            3488, 3372, 3262, 3156, 3056, 2960, 2868, 2780, 2696, 2615,
+            2538, 2463, 2391, 2322, 2256, 2192, 2130, 2071, 2013, 1958,
+            1904, 1852, 1802, 1753, 1706, 1660, 1616, 1573, 1531, 1491,
+            1451, 1413, 1376, 1340, 1305, 1270, 1237, 1205, 1173, 1142,
+            1112, 1083, 1054, 1026,  999,  972,  946,  921,  896,  872,
+             848,  825,  802,  780,  758,  737,  716,  696,  676,  656,
+             637,  618,  600,  581,  564,  546,  529,  512,  496,  480,
+             464,  448,  433,  418,  403,  389,  375,  361,  347,  333,
+             320,  307,  294,  281,  269,  257,  245,  233,  221,  209,
+             198,  187,  176,  165,  155,  144,  134,  123,  113,  103,
+              94,   84,   75,   65,   56
+        }
+        local vfp = vfps[zero_index(refresh - 30)]
+        if vfp == nil then
+            warn("Couldn't do refresh "..refresh.." on Lenovo Legion Go 2 OLED")
+            return base_mode
+        end
+
+        local mode = base_mode
+
+        gamescope.modegen.adjust_front_porch(mode, vfp)
+        mode.vrefresh = gamescope.modegen.calc_vrefresh(mode)
+
+        return mode
+    end,
+    matches = function(display)
+        if display.vendor == "SDC" and display.model and string.find(display.model, "AMS881KB01") then
+            debug("[lenovo_legiongo2_oled] Matched vendor: "..display.vendor.." model: "..display.model)
+            return 5000
+        end
+        return -1
+    end
+}
+debug("Registered Lenovo Legion Go 2 OLED as a known display")


### PR DESCRIPTION
Not sure if this is already being worked on but if not here's a display profile for the Legion Go 2 OLED panel. Luminance values were pulled from [here](https://www.panelook.com/AMS881KB01_Samsung_8.8_Assembly_parameter_69859.html). VFPs for 30hz to 144hz were calculated from 144hz timings in EDID. 

Tested on my Legion Go 2 and confirmed the lua is selected correctly and that it enables new refresh rates, but was not able to confirm some of the lower refresh rates (like 30hz) due to how refresh rates are chosen for a given frame limit. Please let me know if there's a better way to test this.