### PR TITLE
Feat touchpad support

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -159,6 +159,18 @@ const struct option *gamescope_options = (struct option[]){
 
 	{ "allow-deferred-backend", no_argument, nullptr, 0 },
 	{ "keep-alive", no_argument, nullptr, 0 },
+	// Pointer options
+	// Libinput options
+	{ "tap-to-click", no_argument, nullptr, 0 },
+	{ "tap-and-drag", no_argument, nullptr, 0 },
+	{ "drag-lock", no_argument, nullptr, 0 },
+	{ "middle-emulation", no_argument, nullptr, 0 },
+	{ "disable-while-typing", no_argument, nullptr, 0 },
+	{ "disable-while-trackpointing", no_argument, nullptr, 0 },
+	{ "left-handed", no_argument, nullptr, 0 },
+	{ "natural-scrolling", required_argument, nullptr, 0 },
+	{ "pointer-accel-profile", required_argument, nullptr, 0 },
+	{ "pointer-accel-speed", required_argument, nullptr, 0 },
 
 	{} // keep last
 };
@@ -280,6 +292,23 @@ const char usage[] =
 	"Platform options:\n"
 	"  --allow-deferred-backend       Allows initting the backend in a deferred way, if it doesn't work immediately. (Note: This has some very minor correctness compromises that you should consider wrt. your platform with modifiers, etc).\n"
 	"  --keep-alive                   Keep Gamescope alive even when the primary process has died.\n"
+	"Libinput Pointer options:\n"
+	"  --tap-to-click                 enable tap-to-click feature for pointer devices\n"
+	"  --tap-and-drag                 enable tap-and-drag feature for pointer devices\n"
+	"  --drag-lock                    enable drag-lock feature for pointer devices\n"
+	"  --middle-emulation             enable middle button emulation for pointer devices\n"
+	"  --left-handed                  enable left handed mode for pointer devices\n"
+	"  --disable-while-typing         disable pointer devices while typing\n"
+	"  --disable-while-trackpointing  disable pointer devices while trackpointing\n"
+	"  --natural-scrolling            enable natural scrolling for ...\n"
+	"                                     none => No pointer device (default)\n"
+	"                                     touchpad => Only touchpad\n"
+	"                                     mouse => Only mouse\n"
+	"                                     all => All pointer device\n"
+	"  --pointer-accel-profile        set acceleration profile for pointer devices to ...\n"
+	"                                     adaptive => takes the current speed of the device into account when deciding on acceleration (default)\n"
+	"                                     flat => simply a constant factor applied to all device deltas, regardless of the speed of motion\n"
+	"  --pointer-accel-speed          set acceleration speed for pointer devices within [-1, 1] (default 0)\n"
 	"\n"
 	"Keyboard shortcuts:\n"
 	"  Super + F                      toggle fullscreen\n"
@@ -330,6 +359,17 @@ float g_flMaxWindowScale = FLT_MAX;
 
 uint32_t g_preferVendorID = 0;
 uint32_t g_preferDeviceID = 0;
+
+bool g_tapToClick = false;
+bool g_tapAndDrag = false;
+bool g_dragLock = false;
+bool g_middleEmu = false;
+bool g_leftHanded = false;
+bool g_dwt = false;
+bool g_dwtp = false;
+SelectedPointerType g_naturalScrolling = SelectedPointerType::NONE;
+PointerAccelProfileType g_accelProfile = PointerAccelProfileType::ADAPTIVE;
+double g_accelSpeed = false;
 
 pthread_t g_mainThread;
 
@@ -522,6 +562,34 @@ static gamescope::ConCommand cc_shutdown( "shutdown", "Cleanly shutdown gamescop
 	console_log.infof( "Shutting down..." );
 	ShutdownGamescope();
 });
+
+static SelectedPointerType parse_selected_pointer_type(const char* str)
+{
+    if (!str || !*str)
+        return SelectedPointerType::NONE;
+
+    if (!strcmp(str, "all"))
+        return SelectedPointerType::ALL;
+    else if (!strcmp(str, "touchpad"))
+        return SelectedPointerType::TOUCHPAD;
+    else if (!strcmp(str, "mouse"))
+        return SelectedPointerType::MOUSE;
+    else
+	 	return SelectedPointerType::NONE;
+}
+
+static PointerAccelProfileType parse_pointer_accel_profile(const char* str)
+{
+    if (!str || !*str)
+        return PointerAccelProfileType::ADAPTIVE;
+
+    if (!strcmp(str, "adaptive"))
+        return PointerAccelProfileType::ADAPTIVE;
+    else if (!strcmp(str, "flat"))
+        return PointerAccelProfileType::FLAT;
+    else
+        return PointerAccelProfileType::ADAPTIVE;
+}
 
 static void handle_signal( int sig )
 {
@@ -877,6 +945,26 @@ int main(int argc, char **argv)
 								
 						}
 					}
+				} else if (strcmp(opt_name, "tap-to-click") == 0) {
+					g_tapToClick = true;
+				} else if (strcmp(opt_name, "tap-and-drag") == 0) {
+					g_tapAndDrag = true;
+				} else if (strcmp(opt_name, "drag-lock") == 0) {
+					g_dragLock = true;
+				} else if (strcmp(opt_name, "middle-emulation") == 0) {
+					g_middleEmu = true;
+				} else if (strcmp(opt_name, "left-handed") == 0) {
+					g_leftHanded = true;
+				} else if (strcmp(opt_name, "disable-while-typing") == 0) {
+					g_dwt = true;
+				} else if (strcmp(opt_name, "disable-while-trackpointing") == 0) {
+					g_dwtp = true;
+				} else if (strcmp(opt_name, "natural-scrolling") == 0) {
+					g_naturalScrolling = parse_selected_pointer_type( optarg );
+				} else if (strcmp(opt_name, "pointer-accel-profile") == 0) {
+					g_accelProfile = parse_pointer_accel_profile( optarg );
+				} else if (strcmp(opt_name, "pointer-accel-speed") == 0) {
+					g_accelSpeed = atof( optarg );
 				}
 				break;
 			case '?':

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -78,3 +78,31 @@ extern int g_nXWaylandCount;
 extern uint32_t g_preferVendorID;
 extern uint32_t g_preferDeviceID;
 
+void restore_fd_limit( void );
+
+enum class SelectedPointerType : uint32_t
+{
+    NONE,
+    TOUCHPAD,
+    MOUSE,
+    ALL,
+};
+
+enum class PointerAccelProfileType : uint32_t
+{
+    NONE,
+    FLAT,
+    ADAPTIVE,
+    CUSTOM,
+};
+
+extern bool g_tapToClick;
+extern bool g_tapAndDrag;
+extern bool g_dragLock;
+extern bool g_middleEmu;
+extern bool g_leftHanded;
+extern bool g_dwt;
+extern bool g_dwtp;
+extern SelectedPointerType g_naturalScrolling;
+extern PointerAccelProfileType g_accelProfile;
+extern double g_accelSpeed;

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -496,6 +496,116 @@ static void wlserver_handle_touch_motion(struct wl_listener *listener, void *dat
 	wlserver_touchmotion( event->x, event->y, event->touch_id, event->time_msec, false, touch->connector );
 }
 
+static void wlserver_set_libinput_pointer(struct wlr_input_device *device)
+{
+#ifdef HAVE_DRM
+	if (device->type != WLR_INPUT_DEVICE_POINTER || !wlr_input_device_is_libinput(device))
+		return;
+
+	struct libinput_device* libinput_device = wlr_libinput_get_device_handle(device);
+
+	if (g_tapToClick) {
+		libinput_device_config_tap_set_enabled(libinput_device, LIBINPUT_CONFIG_TAP_ENABLED);
+	} else {
+		libinput_device_config_tap_set_enabled(libinput_device, LIBINPUT_CONFIG_TAP_DISABLED);
+	}
+	if (g_tapAndDrag) {
+		libinput_device_config_tap_set_drag_enabled(libinput_device, LIBINPUT_CONFIG_DRAG_ENABLED);
+	} else {
+		libinput_device_config_tap_set_drag_enabled(libinput_device, LIBINPUT_CONFIG_DRAG_DISABLED);
+	}
+	if (g_dragLock) {
+		libinput_device_config_tap_set_drag_lock_enabled(libinput_device, LIBINPUT_CONFIG_DRAG_LOCK_ENABLED);
+	} else {
+		libinput_device_config_tap_set_drag_lock_enabled(libinput_device, LIBINPUT_CONFIG_DRAG_LOCK_DISABLED);
+	}
+	if (libinput_device_config_middle_emulation_is_available(libinput_device)) {
+		if (g_middleEmu) {
+			libinput_device_config_middle_emulation_set_enabled(libinput_device, LIBINPUT_CONFIG_MIDDLE_EMULATION_ENABLED);
+		} else {
+			libinput_device_config_middle_emulation_set_enabled(libinput_device, LIBINPUT_CONFIG_MIDDLE_EMULATION_DISABLED);
+		}
+	} else {
+		if (device->name) {
+			printf("Libinput pointer \"%s\": Middle button emulation not supported", device->name);
+		} else {
+			printf("Unnamed libinput pointer: Middle button emulation not supported");
+		}
+	}
+	if (libinput_device_config_left_handed_is_available(libinput_device)) {
+		libinput_device_config_left_handed_set(libinput_device, g_leftHanded);
+	} else {
+		if (device->name) {
+			printf("Libinput pointer \"%s\": Left handed mode not supported", device->name);
+		} else {
+			printf("Unnamed libinput pointer: Left handed mode not supported");
+		}
+	}
+	if (libinput_device_config_dwt_is_available(libinput_device)) {
+		if (g_dwt) {
+			libinput_device_config_dwt_set_enabled(libinput_device, LIBINPUT_CONFIG_DWT_ENABLED);
+		} else {
+			libinput_device_config_dwt_set_enabled(libinput_device, LIBINPUT_CONFIG_DWT_DISABLED);
+		}
+	} else {
+		if (device->name) {
+			printf("Libinput pointer \"%s\": Disable while typing not supported", device->name);
+		} else {
+			printf("Unnamed libinput pointer: Disable while typing not supported");
+		}
+	}
+	if (libinput_device_config_dwtp_is_available(libinput_device)) {
+		if (g_dwtp) {
+			libinput_device_config_dwtp_set_enabled(libinput_device, LIBINPUT_CONFIG_DWTP_ENABLED);
+		} else {
+			libinput_device_config_dwtp_set_enabled(libinput_device, LIBINPUT_CONFIG_DWTP_DISABLED);
+		}
+	} else {
+		if (device->name) {
+			printf("Libinput pointer \"%s\": Disable while track pointing not supported", device->name);
+		} else {
+			printf("Unnamed libinput pointer: Disable while track pointing not supported");
+		}
+	}
+	if (libinput_device_config_scroll_has_natural_scroll(libinput_device) != 0) {
+		switch (g_naturalScrolling)
+		{
+		case SelectedPointerType::TOUCHPAD:
+			if (libinput_device_config_tap_get_finger_count(libinput_device) != 0)
+				libinput_device_config_scroll_set_natural_scroll_enabled(libinput_device, true);
+			break;
+		case SelectedPointerType::MOUSE:
+			if (libinput_device_config_tap_get_finger_count(libinput_device) == 0)
+				libinput_device_config_scroll_set_natural_scroll_enabled(libinput_device, true);
+			break;
+		case SelectedPointerType::ALL:
+			libinput_device_config_scroll_set_natural_scroll_enabled(libinput_device, true);
+			break;
+		case SelectedPointerType::NONE:
+			break;
+		}
+	}
+	if (libinput_device_config_accel_is_available(libinput_device)) {
+		switch (g_accelProfile) {
+		case PointerAccelProfileType::FLAT:
+			libinput_device_config_accel_set_profile(libinput_device, LIBINPUT_CONFIG_ACCEL_PROFILE_FLAT);
+			break;
+		case PointerAccelProfileType::ADAPTIVE:
+		default:
+			libinput_device_config_accel_set_profile(libinput_device, LIBINPUT_CONFIG_ACCEL_PROFILE_ADAPTIVE);
+			break;
+		}
+		libinput_device_config_accel_set_speed(libinput_device, g_accelSpeed);
+	} else {
+		if (device->name) {
+			printf("Libinput pointer \"%s\": Accelation not supported", device->name);
+		} else {
+			printf("Unnamed libinput pointer: Accelation not supported");
+		}
+	}
+#endif
+}
+
 static void wlserver_new_input(struct wl_listener *listener, void *data)
 {
 	struct wlr_input_device *device = (struct wlr_input_device *) data;
@@ -535,6 +645,8 @@ static void wlserver_new_input(struct wl_listener *listener, void *data)
 			wl_signal_add( &pointer->wlr->events.axis, &pointer->axis);
 			pointer->frame.notify = wlserver_handle_pointer_frame;
 			wl_signal_add( &pointer->wlr->events.frame, &pointer->frame);
+
+			wlserver_set_libinput_pointer(device);
 		}
 		break;
 		case WLR_INPUT_DEVICE_TOUCH:


### PR DESCRIPTION
This PR ports essential libinput pointer and touchpad configuration support from [SkorionOS/gamescope](https://github.com/SkorionOS/gamescope/pull/3) by @chenx-dust. 

This enables touchpad features in Game Mode that are currently missing, significantly improving the experience for laptop users. Currently there is virtually no way to expose libinput config of the touchpads in game mode.

# Features Added

- --tap-to-click: Enable tap-to-click on touchpad devices.
- --natural-scrolling: Support natural scrolling (inverted scroll) for touchpads.
- --tap-and-drag: Enable tap-and-drag functionality.
- --drag-lock: Support for drag lock.
- --middle-emulation, --left-handed, --disable-while-typing, etc.



# Implementation

The patches are ported from
- [SkorionOS/gamescope/pull/3](https://github.com/SkorionOS/gamescope/pull/3)
- [SkorionOS/gamescope/pull/4](https://github.com/SkorionOS/gamescope/pull/4)
- [SkorionOS/gamescope/pull/5](https://github.com/SkorionOS/gamescope/pull/5)
, which has been proven stable in their production environment.



Related upstream PR: [ValveSoftware/gamescope#1406](https://github.com/ValveSoftware/gamescope/pull/1406).



# Testing Performed

- Hardware: HP Elitebook X G1a
- Touchpad Model: SYNA3134:00 06CB:CFE2 Touchpad
- OS Version: bazzite-deck:stable, 43.20260101
- Testing Method: 
    - Built the binary in distrobox (fedora-42 image) 
    - used `env GAMESCOPE_BIN="/var/home/lfy/MyDoc/gamescope/build/src/gamescope --tap-to-click --natural-scrolling touchpad --tap-and-drag --drag-lock"` to inject launch options into `gamescope-session-plus`

# Verified:

All existing unit tests passed.
Newly added options are working in Steam Game Mode.


# Note

While this PR adds binary support for these flags, further work might be needed in gamescope-session-plus to expose these as configurable toggles. However, providing the underlying support in the compositor is the first critical step.