### PR TITLE
Fix NVIDIA-specific black screen/inverted colors when streaming via Steam Remote Play atop gamescope.

### DIFF
--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -464,14 +464,20 @@ bool CVulkanDevice::createDevice()
 	// We need to refactor some Vulkan stuff to do that though.
 	if ( hasDrmProps )
 	{
+		VkPhysicalDeviceDriverProperties driverProps = {
+			.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRIVER_PROPERTIES,
+		};
 		VkPhysicalDeviceDrmPropertiesEXT drmProps = {
 			.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRM_PROPERTIES_EXT,
+			.pNext = &driverProps,
 		};
 		VkPhysicalDeviceProperties2 props2 = {
 			.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2,
 			.pNext = &drmProps,
 		};
 		vk.GetPhysicalDeviceProperties2( physDev(), &props2 );
+
+		m_bIsNvidiaProprietaryDriver = driverProps.driverID == VK_DRIVER_ID_NVIDIA_PROPRIETARY;
 
 		if ( !GetBackend()->UsesVulkanSwapchain() && !drmProps.hasPrimary ) {
 			vk_log.errorf( "physical device has no primary node" );
@@ -3638,6 +3644,7 @@ gamescope::Rc<CVulkanTexture> vulkan_acquire_screenshot_texture(uint32_t width, 
 			screenshotImageFlags.bMappable = true;
 			screenshotImageFlags.bTransferDst = true;
 			screenshotImageFlags.bStorage = true;
+			screenshotImageFlags.bSampled = true; // required for RGB-to-NV12 shader to sample this texture
 			if (exportable || drmFormat == DRM_FORMAT_NV12) {
 				screenshotImageFlags.bExportable = true;
 				screenshotImageFlags.bLinear = true; // TODO: support multi-planar DMA-BUF export via PipeWire

--- a/src/rendervulkan.hpp
+++ b/src/rendervulkan.hpp
@@ -810,6 +810,7 @@ public:
 	inline bool hasDrmPrimaryDevId() {return m_bHasDrmPrimaryDevId;}
 	inline dev_t primaryDevId() {return m_drmPrimaryDevId;}
 	inline bool supportsFp16() {return m_bSupportsFp16;}
+	inline bool isNvidiaProprietaryDriver() {return m_bIsNvidiaProprietaryDriver;}
 
 	inline std::pair<void *, uint32_t> uploadBufferData(uint32_t size)
 	{
@@ -873,6 +874,7 @@ protected:
 	bool m_bSupportsFp16 = false;
 	bool m_bHasDrmPrimaryDevId = false;
 	bool m_bSupportsModifiers = false;
+	bool m_bIsNvidiaProprietaryDriver = false;
 	bool m_bInitialized = false;
 
 

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -2388,8 +2388,15 @@ static void paint_pipewire()
 	if ( pFocus->overrideWindow && !pFocus->focusWindow->isSteamStreamingClient )
 		paint_window( pFocus->overrideWindow, pFocus->focusWindow, &frameInfo, nullptr, PaintWindowFlag::NoFilter, 1.0f, pFocus->overrideWindow );
 
+	// On the NVIDIA proprietary driver, sampling VK_FORMAT_A2R10G10B10_UNORM_PACK32
+	// (DRM_FORMAT_XRGB2101010) storage images returns R and B swapped, causing colour
+	// inversion in the RGB-to-NV12 conversion shader. Use DRM_FORMAT_XBGR2101010
+	// (VK_FORMAT_A2B10G10R10_UNORM_PACK32) instead so components arrive in the correct
+	// order. This does not affect non-proprietary NVIDIA drivers or other vendors.
+	const uint32_t uRGBCaptureFormat = g_device.isNvidiaProprietaryDriver()
+		? DRM_FORMAT_XBGR2101010 : DRM_FORMAT_XRGB2101010;
 	gamescope::Rc<CVulkanTexture> pRGBTexture = s_pPipewireBuffer->texture->isYcbcr()
-		? vulkan_acquire_screenshot_texture( uWidth, uHeight, false, DRM_FORMAT_XRGB2101010 )
+		? vulkan_acquire_screenshot_texture( uWidth, uHeight, false, uRGBCaptureFormat )
 		: gamescope::Rc<CVulkanTexture>{ s_pPipewireBuffer->texture };
 
 	gamescope::Rc<CVulkanTexture> pYUVTexture = s_pPipewireBuffer->texture->isYcbcr() ? s_pPipewireBuffer->texture : nullptr;


### PR DESCRIPTION
These changes detect the NVIDIA proprietary driver via VkPhysicalDeviceDriverProperties and apply two fixes for Steam Remote Play with Gamescope (running steam within gamescope, in 'deck mode' for example):

1. Black screen fix: The screenshot texture was not marked as bSampled, which is required for the RGB-to-NV12 conversion shader to sample it on NVIDIA. This caused a black screen when streaming via Remote Play.
2. Inverted R/B colour fix: Once the black screen was resolved, it was discovered that sampling VK_FORMAT_A2R10G10B10_UNORM_PACK32 storage images on the NVIDIA proprietary driver returns the R and B channels swapped in the shader. When the proprietary driver is detected, DRM_FORMAT_XBGR2101010 is used instead of DRM_FORMAT_XRGB2101010 for the RGB capture texture, so the components arrive in the correct order.

Neither fix affects mesa or other vendors.

I have also submitted this PR upstream, but since bazzite is fast-moving and has dedicated NVIDIA deck images, I think it would potentially be appropriate and helpful to users, to include this fix.

Upstream PR is here:
https://github.com/ValveSoftware/gamescope/pull/2094